### PR TITLE
Use tabs instead of spaces in snippets

### DIFF
--- a/snippets/double-quotes/afterEachESNext.sublime-snippetx
+++ b/snippets/double-quotes/afterEachESNext.sublime-snippetx
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 afterEach(() => {
-  $1
+	$1
 });]]>
   </content>
   <tabTrigger><![CDATA[aee]]></tabTrigger>

--- a/snippets/double-quotes/beforeEachESNext.sublime-snippetx
+++ b/snippets/double-quotes/beforeEachESNext.sublime-snippetx
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 beforeEach(() => {
-  $1
+	$1
 });]]>
   </content>
   <tabTrigger><![CDATA[bee]]></tabTrigger>

--- a/snippets/double-quotes/describeESNext.sublime-snippetx
+++ b/snippets/double-quotes/describeESNext.sublime-snippetx
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 describe("${1:Name of the group}", () => {
-  $2
+	$2
 });]]>
   </content>
   <tabTrigger><![CDATA[desce]]></tabTrigger>

--- a/snippets/double-quotes/itESNext.sublime-snippetx
+++ b/snippets/double-quotes/itESNext.sublime-snippetx
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 it("${1:should behave...}", () => {
-  $2
+	$2
 });]]>
   </content>
   <tabTrigger><![CDATA[ite]]></tabTrigger>

--- a/snippets/double-quotes/xdescribeESNext.sublime-snippetx
+++ b/snippets/double-quotes/xdescribeESNext.sublime-snippetx
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 xdescribe("${1:Name of the group}", () => {
-  $2
+	$2
 });]]>
   </content>
   <tabTrigger><![CDATA[xdesce]]></tabTrigger>

--- a/snippets/double-quotes/xitESNext.sublime-snippetx
+++ b/snippets/double-quotes/xitESNext.sublime-snippetx
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 xit("${1:should behave...}", () => {
-  $2
+	$2
 });]]>
   </content>
   <tabTrigger><![CDATA[xite]]></tabTrigger>

--- a/snippets/single-quotes/afterEachESNext.sublime-snippet
+++ b/snippets/single-quotes/afterEachESNext.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 afterEach(() => {
-  $1
+	$1
 });]]>
   </content>
   <tabTrigger><![CDATA[aee]]></tabTrigger>

--- a/snippets/single-quotes/beforeEachESNext.sublime-snippet
+++ b/snippets/single-quotes/beforeEachESNext.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 beforeEach(() => {
-  $1
+	$1
 });]]>
   </content>
   <tabTrigger><![CDATA[bee]]></tabTrigger>

--- a/snippets/single-quotes/describeESNext.sublime-snippet
+++ b/snippets/single-quotes/describeESNext.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 describe('${1:Name of the group}', () => {
-  $2
+	$2
 });]]>
   </content>
   <tabTrigger><![CDATA[desce]]></tabTrigger>

--- a/snippets/single-quotes/itESNext.sublime-snippet
+++ b/snippets/single-quotes/itESNext.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 it('${1:should behave...}', () => {
-  $2
+	$2
 });]]>
   </content>
   <tabTrigger><![CDATA[ite]]></tabTrigger>

--- a/snippets/single-quotes/xdescribeESNext.sublime-snippet
+++ b/snippets/single-quotes/xdescribeESNext.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 xdescribe('${1:Name of the group}', () => {
-  $2
+	$2
 });]]>
   </content>
   <tabTrigger><![CDATA[xdesce]]></tabTrigger>

--- a/snippets/single-quotes/xitESNext.sublime-snippet
+++ b/snippets/single-quotes/xitESNext.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 xit('${1:should behave...}', () => {
-  $2
+	$2
 });]]>
   </content>
   <tabTrigger><![CDATA[xite]]></tabTrigger>


### PR DESCRIPTION
According to sublimetext.info, and based on my own tests, snippets which are inserting indentation (such as a beforeEach snippet) should use tabs. Sublime Text will convert tabs into the spaces if the user has that chosen that configuration option for their editor.

EDIT: To be clear, this came out of me using the esNext snippets and finding they'd insert two spaces regardless of my configuration settings for that file.